### PR TITLE
fix: サービス一覧取得前に1秒スリープを挟む

### DIFF
--- a/.github/workflows/get-service-list.yml
+++ b/.github/workflows/get-service-list.yml
@@ -23,13 +23,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: run
-        run: |
-          aws iam get-service-last-accessed-details --job-id `aws iam generate-service-last-accessed-details --arn arn:aws:iam::aws:policy/AdministratorAccess --output text` --max-items 1000
-
       - name: Update AWS Service List in us-east-1
-        run: |
-          aws iam get-service-last-accessed-details --job-id `aws iam generate-service-last-accessed-details --arn arn:aws:iam::aws:policy/AdministratorAccess --output text` --max-items 1000  | jq '.ServicesLastAccessed | sort_by(.ServiceName) | map({ServiceName: .ServiceName})' > us-east-1.json
+        run: >
+          i=`aws iam generate-service-last-accessed-details --arn arn:aws:iam::aws:policy/AdministratorAccess --output text`
+          && sleep 1
+          && aws iam get-service-last-accessed-details --job-id $i --max-items 1000
+          | jq '.ServicesLastAccessed
+          | sort_by(.ServiceName)
+          | map({ServiceName: .ServiceName})'
+          > us-east-1.json
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
- ジョブ実行直後だとエラーが出ることがあるようなので、サービス一覧取得前に1秒スリープを挟んだ
- 重複していたジョブ実行&サービス一覧取得処理の削除

参考: https://dev.classmethod.jp/articles/all-aws-services-onliner/